### PR TITLE
Add `use` option to sources, and `default-use` to the settings.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changes
 3.0.0b2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add ``use`` option to sources, and ``default-use`` to the settings.
+  ``default-use`` is true by default.  When false, the source is not
+  checked out, and the version for this package is not overridden.
+  [maurits]
 
 
 3.0.0b1 (2022-11-21)

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,10 @@ In the main sections the input and output files are defined.
             somefancypackage
             otherpackage
 
+``default-use``:
+  True by default.  When false, the source is not checked out,
+  and the version for this package is not overridden.
+
 Additional, custom variables can be defined as ``key = value`` pair.
 Those can be referenced in other values as ``${settings:key}`` and will be expanded there.
 
@@ -157,6 +161,11 @@ All other sections are defining the sources to be used.
 
 
     Defaults to default mode configured in main section ``[settings]`` ``default-install-mode =`` value.
+
+``use``:
+  True by default, unless ``default-use`` in the general settings is false.
+  When false, the source is not checked out,
+  and the version for this package is not overridden.
 
 ``submodules``
     There are 3 different options

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,3 +85,9 @@ universal = 1
 # TODO: Remove current max-line-lengh ignore in follow-up and adopt black limit.
 # max-line-length = 88
 ignore = D001
+
+
+[check-manifest]
+ignore =
+    Makefile
+    mx.ini


### PR DESCRIPTION
`default-use` is true by default.  When false, the source is not checked out, and the version for this package is not overridden.

Part of https://github.com/plone/Products.CMFPlone/issues/3670