### PR TITLE
 Fix usage of "--install-option='pre'" and use "--pre" option in requirements files instead.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ### 3.0.0b3 (unreleased)
 
+- Fix usage of "--install-option='pre'" and use "--pre" option in requirements files instead.
+  The install options is deprecated in pip 23 which Plone switched to recently.
+  More info:
+  https://github.com/pypa/pip/issues/11358
+  https://discuss.python.org/t/passing-command-line-arguments-to-pip-install-after-install-options-deprecation/22981/6
+  [thet, fredvd]
+
 - Fix reading sections from config parser without defaults if section contains setting which also exists as default.
   [rnix]
 

--- a/src/mxdev/processing.py
+++ b/src/mxdev/processing.py
@@ -205,7 +205,7 @@ def write_dev_sources(fio, packages: typing.Dict[str, typing.Dict[str, typing.An
             continue
         extras = f"[{package['extras']}]" if package["extras"] else ""
         subdir = f"/{package['subdirectory']}" if package["subdirectory"] else ""
-        install_options = ' --install-option="--pre"'
+        install_options = ' --pre'
         editable = (
             f"""-e ./{package['target']}/{name}{subdir}{extras}{install_options}\n"""
         )


### PR DESCRIPTION
The install options is deprecated in pip 23 which Plone switched to recently.

More info:
- https://github.com/pypa/pip/issues/11358
- https://discuss.python.org/t/passing-command-line-arguments-to-pip-install-after-install-options-deprecation/22981/6

NOTE: this is breaking Plone PR builds currently.
See: https://github.com/plone/plone.app.mosaic/actions/runs/4768963939/jobs/8478862820?pr=535